### PR TITLE
Fix struct types

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -1,16 +1,15 @@
 package intercom
 
 import (
-	"encoding/json"
 	"fmt"
 )
 
 // Admin represents an Admin in Intercom.
 type Admin struct {
-	ID    json.Number `json:"id"`
-	Type  string      `json:"type"`
-	Name  string      `json:"name"`
-	Email string      `json:"email"`
+	ID    string `json:"id"`
+	Type  string `json:"type"`
+	Name  string `json:"name"`
+	Email string `json:"email"`
 }
 
 // AdminList represents an object holding list of Admins
@@ -37,7 +36,7 @@ func (a Admin) IsNobodyAdmin() bool {
 func (a Admin) MessageAddress() MessageAddress {
 	return MessageAddress{
 		Type: "admin",
-		ID:   a.ID.String(),
+		ID:   a.ID,
 	}
 }
 

--- a/conversation.go
+++ b/conversation.go
@@ -73,7 +73,7 @@ func (c *ConversationService) ListByAdmin(admin *Admin, state ConversationListSt
 	params := conversationListParams{
 		PageParams: pageParams,
 		Type:       "admin",
-		AdminID:    admin.ID.String(),
+		AdminID:    admin.ID,
 	}
 	if state == SHOW_OPEN {
 		params.Open = Bool(true)

--- a/user.go
+++ b/user.go
@@ -2,7 +2,6 @@ package intercom
 
 import (
 	"fmt"
-	"encoding/json"
 )
 
 // UserService handles interactions with the API through a UserRepository.
@@ -12,8 +11,8 @@ type UserService struct {
 
 // UserList holds a list of Users and paging information
 type UserList struct {
-	Pages PageParams
-	Users []User
+	Pages       PageParams
+	Users       []User
 	ScrollParam string `json:"scroll_param,omitempty"`
 }
 
@@ -69,10 +68,10 @@ type SocialProfileList struct {
 
 // SocialProfile represents a social account for a User.
 type SocialProfile struct {
-	Name     string      `json:"name,omitempty"`
-	ID       json.Number `json:"id,omitempty"`
-	Username string      `json:"username,omitempty"`
-	URL      string      `json:"url,omitempty"`
+	Name     string `json:"name,omitempty"`
+	ID       string `json:"id,omitempty"`
+	Username string `json:"username,omitempty"`
+	URL      string `json:"url,omitempty"`
 }
 
 // UserIdentifiers are used to identify Users in Intercom.
@@ -95,7 +94,7 @@ type userListParams struct {
 }
 
 type scrollParams struct {
-	ScrollParam  string `url:"scroll_param,omitempty"`
+	ScrollParam string `url:"scroll_param,omitempty"`
 }
 
 // FindByID looks up a User by their Intercom ID.
@@ -124,7 +123,7 @@ func (u *UserService) List(params PageParams) (UserList, error) {
 
 // List all Users for App via Scroll API
 func (u *UserService) Scroll(scrollParam string) (UserList, error) {
-       return u.Repository.scroll(scrollParam)
+	return u.Repository.scroll(scrollParam)
 }
 
 // List Users by Segment.


### PR DESCRIPTION
The intercom docs state the admin and user social profile ID's are
of type string, most of the time they are numeric strings so there's
no problem, however if they are a string or alphanumeric string
then when working with these object using json, for example, causes
errors to occur as the data cannot be marshalled.

The Admin change is a preemptive fix where the same issue can occur.

https://developers.intercom.com/v2.0/reference#admin-model
https://developers.intercom.com/v2.0/reference#section-social-profile-object