### PR TITLE
Minor Perf Updates

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -49,7 +49,7 @@ type AdminService struct {
 }
 
 // List lists the Admins associated with your App.
-func (c *AdminService) List() (AdminList, error) {
+func (c *AdminService) List() (*AdminList, error) {
 	return c.Repository.list()
 }
 

--- a/admin_api.go
+++ b/admin_api.go
@@ -1,14 +1,12 @@
 package intercom
 
 import (
-	"encoding/json"
-
 	"gopkg.in/intercom/intercom-go.v2/interfaces"
 )
 
 // AdminRepository defines the interface for working with Admins through the API.
 type AdminRepository interface {
-	list() (AdminList, error)
+	list() (*AdminList, error)
 }
 
 // AdminAPI implements AdminRepository
@@ -16,12 +14,8 @@ type AdminAPI struct {
 	httpClient interfaces.HTTPClient
 }
 
-func (api AdminAPI) list() (AdminList, error) {
-	adminList := AdminList{}
-	data, err := api.httpClient.Get("/admins", nil)
-	if err != nil {
-		return adminList, err
-	}
-	err = json.Unmarshal(data, &adminList)
-	return adminList, err
+func (api AdminAPI) list() (*AdminList, error) {
+	var list *AdminList
+	err := api.httpClient.Get("/admins", nil, &list)
+	return list, err
 }

--- a/admin_api_test.go
+++ b/admin_api_test.go
@@ -1,6 +1,7 @@
 package intercom
 
 import (
+	"encoding/json"
 	"io/ioutil"
 	"testing"
 )
@@ -21,9 +22,13 @@ type TestAdminHTTPClient struct {
 	expectedURI     string
 }
 
-func (t TestAdminHTTPClient) Get(uri string, queryParams interface{}) ([]byte, error) {
+func (t TestAdminHTTPClient) Get(uri string, queryParams interface{}, v interface{}) error {
 	if t.expectedURI != uri {
 		t.t.Errorf("URI was %s, expected %s", uri, t.expectedURI)
 	}
-	return ioutil.ReadFile(t.fixtureFilename)
+	b, err := ioutil.ReadFile(t.fixtureFilename)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(b, v)
 }

--- a/admin_test.go
+++ b/admin_test.go
@@ -35,6 +35,6 @@ type TestAdminAPI struct {
 	t *testing.T
 }
 
-func (t TestAdminAPI) list() (AdminList, error) {
-	return AdminList{Admins: []Admin{Admin{ID: "213"}}}, nil
+func (t TestAdminAPI) list() (*AdminList, error) {
+	return &AdminList{Admins: []Admin{Admin{ID: "213"}}}, nil
 }

--- a/company.go
+++ b/company.go
@@ -55,42 +55,42 @@ type companyListParams struct {
 }
 
 // FindByID finds a Company using their Intercom ID
-func (c *CompanyService) FindByID(id string) (Company, error) {
+func (c *CompanyService) FindByID(id string) (*Company, error) {
 	return c.findWithIdentifiers(CompanyIdentifiers{ID: id})
 }
 
 // FindByCompanyID finds a Company using their CompanyID
 // CompanyID is a customer-defined field
-func (c *CompanyService) FindByCompanyID(companyID string) (Company, error) {
+func (c *CompanyService) FindByCompanyID(companyID string) (*Company, error) {
 	return c.findWithIdentifiers(CompanyIdentifiers{CompanyID: companyID})
 }
 
 // FindByName finds a Company using their Name
-func (c *CompanyService) FindByName(name string) (Company, error) {
+func (c *CompanyService) FindByName(name string) (*Company, error) {
 	return c.findWithIdentifiers(CompanyIdentifiers{Name: name})
 }
 
-func (c *CompanyService) findWithIdentifiers(identifiers CompanyIdentifiers) (Company, error) {
+func (c *CompanyService) findWithIdentifiers(identifiers CompanyIdentifiers) (*Company, error) {
 	return c.Repository.find(identifiers)
 }
 
 // List Companies
-func (c *CompanyService) List(params PageParams) (CompanyList, error) {
+func (c *CompanyService) List(params PageParams) (*CompanyList, error) {
 	return c.Repository.list(companyListParams{PageParams: params})
 }
 
 // List Companies by Segment
-func (c *CompanyService) ListBySegment(segmentID string, params PageParams) (CompanyList, error) {
+func (c *CompanyService) ListBySegment(segmentID string, params PageParams) (*CompanyList, error) {
 	return c.Repository.list(companyListParams{PageParams: params, SegmentID: segmentID})
 }
 
 // List Companies by Tag
-func (c *CompanyService) ListByTag(tagID string, params PageParams) (CompanyList, error) {
+func (c *CompanyService) ListByTag(tagID string, params PageParams) (*CompanyList, error) {
 	return c.Repository.list(companyListParams{PageParams: params, TagID: tagID})
 }
 
 // List all Companies for App via Scroll API
-func (c *CompanyService) Scroll(scrollParam string) (CompanyList, error) {
+func (c *CompanyService) Scroll(scrollParam string) (*CompanyList, error) {
 	return c.Repository.scroll(scrollParam)
 }
 

--- a/company_api.go
+++ b/company_api.go
@@ -10,9 +10,9 @@ import (
 
 // CompanyRepository defines the interface for working with Companies through the API.
 type CompanyRepository interface {
-	find(CompanyIdentifiers) (Company, error)
-	list(companyListParams) (CompanyList, error)
-	scroll(scrollParam string) (CompanyList, error)
+	find(CompanyIdentifiers) (*Company, error)
+	list(companyListParams) (*CompanyList, error)
+	scroll(scrollParam string) (*CompanyList, error)
 	save(*Company) (Company, error)
 }
 
@@ -31,45 +31,33 @@ type requestCompany struct {
 	CustomAttributes map[string]interface{} `json:"custom_attributes,omitempty"`
 }
 
-func (api CompanyAPI) find(params CompanyIdentifiers) (Company, error) {
-	company := Company{}
-	data, err := api.getClientForFind(params)
-	if err != nil {
-		return company, err
-	}
-	err = json.Unmarshal(data, &company)
+func (api CompanyAPI) find(params CompanyIdentifiers) (*Company, error) {
+	var company *Company
+	err := api.getClientForFind(params, &company)
 	return company, err
 }
 
-func (api CompanyAPI) getClientForFind(params CompanyIdentifiers) ([]byte, error) {
+func (api CompanyAPI) getClientForFind(params CompanyIdentifiers, v interface{}) error {
 	switch {
 	case params.ID != "":
-		return api.httpClient.Get(fmt.Sprintf("/companies/%s", params.ID), nil)
+		return api.httpClient.Get(fmt.Sprintf("/companies/%s", params.ID), nil, v)
 	case params.CompanyID != "", params.Name != "":
-		return api.httpClient.Get("/companies", params)
+		return api.httpClient.Get("/companies", params, v)
 	}
-	return nil, errors.New("Missing Company Identifier")
+	return errors.New("Missing Company Identifier")
 }
 
-func (api CompanyAPI) list(params companyListParams) (CompanyList, error) {
-	companyList := CompanyList{}
-	data, err := api.httpClient.Get("/companies", params)
-	if err != nil {
-		return companyList, err
-	}
-	err = json.Unmarshal(data, &companyList)
-	return companyList, err
+func (api CompanyAPI) list(params companyListParams) (*CompanyList, error) {
+	var list *CompanyList
+	err := api.httpClient.Get("/companies", params, &list)
+	return list, err
 }
 
-func (api CompanyAPI) scroll(scrollParam string) (CompanyList, error) {
-	companyList := CompanyList{}
-	params := scrollParams{ScrollParam: scrollParam }
-	data, err := api.httpClient.Get("/companies/scroll", params)
-	if err != nil {
-		return companyList, err
-	}
-	err = json.Unmarshal(data, &companyList)
-	return companyList, err
+func (api CompanyAPI) scroll(scrollParam string) (*CompanyList, error) {
+	var list *CompanyList
+	params := scrollParams{ScrollParam: scrollParam}
+	err := api.httpClient.Get("/companies/scroll", params, &list)
+	return list, err
 }
 
 func (api CompanyAPI) save(company *Company) (Company, error) {

--- a/company_api_test.go
+++ b/company_api_test.go
@@ -1,6 +1,7 @@
 package intercom
 
 import (
+	"encoding/json"
 	"io/ioutil"
 	"testing"
 )
@@ -63,11 +64,15 @@ type TestCompanyHTTPClient struct {
 	expectedURI     string
 }
 
-func (t TestCompanyHTTPClient) Get(uri string, queryParams interface{}) ([]byte, error) {
+func (t TestCompanyHTTPClient) Get(uri string, queryParams interface{}, v interface{}) error {
 	if t.expectedURI != uri {
 		t.t.Errorf("URI was %s, expected %s", uri, t.expectedURI)
 	}
-	return ioutil.ReadFile(t.fixtureFilename)
+	b, err := ioutil.ReadFile(t.fixtureFilename)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(b, v)
 }
 
 func (t TestCompanyHTTPClient) Post(uri string, body interface{}) ([]byte, error) {

--- a/company_test.go
+++ b/company_test.go
@@ -43,16 +43,16 @@ type TestCompanyAPI struct {
 	t *testing.T
 }
 
-func (t TestCompanyAPI) find(params CompanyIdentifiers) (Company, error) {
-	return Company{ID: params.ID, Name: params.Name, CompanyID: params.CompanyID}, nil
+func (t TestCompanyAPI) find(params CompanyIdentifiers) (*Company, error) {
+	return &Company{ID: params.ID, Name: params.Name, CompanyID: params.CompanyID}, nil
 }
 
-func (t TestCompanyAPI) list(params companyListParams) (CompanyList, error) {
-	return CompanyList{Companies: []Company{Company{ID: "46adad3f09126dca", Name: "My Co", CompanyID: "aa123"}}}, nil
+func (t TestCompanyAPI) list(params companyListParams) (*CompanyList, error) {
+	return &CompanyList{Companies: []Company{Company{ID: "46adad3f09126dca", Name: "My Co", CompanyID: "aa123"}}}, nil
 }
 
-func (t TestCompanyAPI) scroll(scrollParam string) (CompanyList, error) {
-	return CompanyList{Companies: []Company{Company{ID: "46adad3f09126dca", Name: "My Co", CompanyID: "aa123"}}}, nil
+func (t TestCompanyAPI) scroll(scrollParam string) (*CompanyList, error) {
+	return &CompanyList{Companies: []Company{Company{ID: "46adad3f09126dca", Name: "My Co", CompanyID: "aa123"}}}, nil
 }
 
 func (t TestCompanyAPI) save(company *Company) (Company, error) {

--- a/contact.go
+++ b/contact.go
@@ -9,8 +9,8 @@ type ContactService struct {
 
 // ContactList holds a list of Contacts and paging information
 type ContactList struct {
-	Pages    PageParams
-	Contacts []Contact
+	Pages       PageParams
+	Contacts    []Contact
 	ScrollParam string `json:"scroll_param,omitempty"`
 }
 
@@ -49,41 +49,41 @@ type contactListParams struct {
 }
 
 // FindByID looks up a Contact by their Intercom ID.
-func (c *ContactService) FindByID(id string) (Contact, error) {
+func (c *ContactService) FindByID(id string) (*Contact, error) {
 	return c.findWithIdentifiers(UserIdentifiers{ID: id})
 }
 
 // FindByUserID looks up a Contact by their UserID (automatically generated server side).
-func (c *ContactService) FindByUserID(userID string) (Contact, error) {
+func (c *ContactService) FindByUserID(userID string) (*Contact, error) {
 	return c.findWithIdentifiers(UserIdentifiers{UserID: userID})
 }
 
-func (c *ContactService) findWithIdentifiers(identifiers UserIdentifiers) (Contact, error) {
+func (c *ContactService) findWithIdentifiers(identifiers UserIdentifiers) (*Contact, error) {
 	return c.Repository.find(identifiers)
 }
 
 // List all Contacts for App.
-func (c *ContactService) List(params PageParams) (ContactList, error) {
+func (c *ContactService) List(params PageParams) (*ContactList, error) {
 	return c.Repository.list(contactListParams{PageParams: params})
 }
 
 // List all Contacts for App via Scroll API
-func (c *ContactService) Scroll(scrollParam string) (ContactList, error) {
-       return c.Repository.scroll(scrollParam)
+func (c *ContactService) Scroll(scrollParam string) (*ContactList, error) {
+	return c.Repository.scroll(scrollParam)
 }
 
 // ListByEmail looks up a list of Contacts by their Email.
-func (c *ContactService) ListByEmail(email string, params PageParams) (ContactList, error) {
+func (c *ContactService) ListByEmail(email string, params PageParams) (*ContactList, error) {
 	return c.Repository.list(contactListParams{PageParams: params, Email: email})
 }
 
 // List Contacts by Segment.
-func (c *ContactService) ListBySegment(segmentID string, params PageParams) (ContactList, error) {
+func (c *ContactService) ListBySegment(segmentID string, params PageParams) (*ContactList, error) {
 	return c.Repository.list(contactListParams{PageParams: params, SegmentID: segmentID})
 }
 
 // List Contacts By Tag.
-func (c *ContactService) ListByTag(tagID string, params PageParams) (ContactList, error) {
+func (c *ContactService) ListByTag(tagID string, params PageParams) (*ContactList, error) {
 	return c.Repository.list(contactListParams{PageParams: params, TagID: tagID})
 }
 

--- a/contact_test.go
+++ b/contact_test.go
@@ -94,16 +94,16 @@ type TestContactAPI struct {
 	t *testing.T
 }
 
-func (t TestContactAPI) find(params UserIdentifiers) (Contact, error) {
-	return Contact{ID: params.ID, Email: params.Email, UserID: params.UserID}, nil
+func (t TestContactAPI) find(params UserIdentifiers) (*Contact, error) {
+	return &Contact{ID: params.ID, Email: params.Email, UserID: params.UserID}, nil
 }
 
-func (t TestContactAPI) list(params contactListParams) (ContactList, error) {
-	return ContactList{Contacts: []Contact{Contact{ID: "46adad3f09126dca", Email: "jamie@example.io", UserID: "aa123"}}}, nil
+func (t TestContactAPI) list(params contactListParams) (*ContactList, error) {
+	return &ContactList{Contacts: []Contact{Contact{ID: "46adad3f09126dca", Email: "jamie@example.io", UserID: "aa123"}}}, nil
 }
 
-func (t TestContactAPI) scroll(scrollParam string) (ContactList, error) {
-	return ContactList{Contacts: []Contact{Contact{ID: "46adad3f09126dca", Email: "jamie@example.io", UserID: "aa123"}}}, nil
+func (t TestContactAPI) scroll(scrollParam string) (*ContactList, error) {
+	return &ContactList{Contacts: []Contact{Contact{ID: "46adad3f09126dca", Email: "jamie@example.io", UserID: "aa123"}}}, nil
 }
 
 func (t TestContactAPI) create(c *Contact) (Contact, error) {

--- a/conversation.go
+++ b/conversation.go
@@ -64,12 +64,12 @@ const (
 )
 
 // List all Conversations
-func (c *ConversationService) ListAll(pageParams PageParams) (ConversationList, error) {
+func (c *ConversationService) ListAll(pageParams PageParams) (*ConversationList, error) {
 	return c.Repository.list(conversationListParams{PageParams: pageParams})
 }
 
 // List Conversations by Admin
-func (c *ConversationService) ListByAdmin(admin *Admin, state ConversationListState, pageParams PageParams) (ConversationList, error) {
+func (c *ConversationService) ListByAdmin(admin *Admin, state ConversationListState, pageParams PageParams) (*ConversationList, error) {
 	params := conversationListParams{
 		PageParams: pageParams,
 		Type:       "admin",
@@ -85,7 +85,7 @@ func (c *ConversationService) ListByAdmin(admin *Admin, state ConversationListSt
 }
 
 // List Conversations by User
-func (c *ConversationService) ListByUser(user *User, state ConversationListState, pageParams PageParams) (ConversationList, error) {
+func (c *ConversationService) ListByUser(user *User, state ConversationListState, pageParams PageParams) (*ConversationList, error) {
 	params := conversationListParams{
 		PageParams:     pageParams,
 		Type:           "user",
@@ -100,7 +100,7 @@ func (c *ConversationService) ListByUser(user *User, state ConversationListState
 }
 
 // Find Conversation by conversation id
-func (c *ConversationService) Find(id string) (Conversation, error) {
+func (c *ConversationService) Find(id string) (*Conversation, error) {
 	return c.Repository.find(id)
 }
 

--- a/conversation_api.go
+++ b/conversation_api.go
@@ -9,8 +9,8 @@ import (
 
 // ConversationRepository defines the interface for working with Conversations through the API.
 type ConversationRepository interface {
-	find(id string) (Conversation, error)
-	list(params conversationListParams) (ConversationList, error)
+	find(id string) (*Conversation, error)
+	list(params conversationListParams) (*ConversationList, error)
 	read(id string) (Conversation, error)
 	reply(id string, reply *Reply) (Conversation, error)
 }
@@ -24,14 +24,10 @@ type conversationReadRequest struct {
 	Read bool `json:"read"`
 }
 
-func (api ConversationAPI) list(params conversationListParams) (ConversationList, error) {
-	convoList := ConversationList{}
-	data, err := api.httpClient.Get("/conversations", params)
-	if err != nil {
-		return convoList, err
-	}
-	err = json.Unmarshal(data, &convoList)
-	return convoList, err
+func (api ConversationAPI) list(params conversationListParams) (*ConversationList, error) {
+	var list *ConversationList
+	err := api.httpClient.Get("/conversations", params, &list)
+	return list, err
 }
 
 func (api ConversationAPI) read(id string) (Conversation, error) {
@@ -51,15 +47,11 @@ func (api ConversationAPI) reply(id string, reply *Reply) (Conversation, error) 
 		return conversation, err
 	}
 	err = json.Unmarshal(data, &conversation)
-	return conversation, nil
+	return conversation, err
 }
 
-func (api ConversationAPI) find(id string) (Conversation, error) {
-	conversation := Conversation{}
-	data, err := api.httpClient.Get(fmt.Sprintf("/conversations/%s", id), nil)
-	if err != nil {
-		return conversation, err
-	}
-	err = json.Unmarshal(data, &conversation)
+func (api ConversationAPI) find(id string) (*Conversation, error) {
+	var conversation *Conversation
+	err := api.httpClient.Get(fmt.Sprintf("/conversations/%s", id), nil, &conversation)
 	return conversation, err
 }

--- a/conversation_api_test.go
+++ b/conversation_api_test.go
@@ -1,6 +1,7 @@
 package intercom
 
 import (
+	"encoding/json"
 	"io/ioutil"
 	"testing"
 )
@@ -119,14 +120,18 @@ type TestConversationHTTPClient struct {
 	lastQueryParams interface{}
 }
 
-func (t *TestConversationHTTPClient) Get(uri string, queryParams interface{}) ([]byte, error) {
+func (t *TestConversationHTTPClient) Get(uri string, queryParams interface{}, v interface{}) error {
 	if t.testFunc != nil {
 		t.testFunc(t.t, queryParams)
 	}
 	if t.expectedURI != uri {
 		t.t.Errorf("Wrong endpoint called")
 	}
-	return ioutil.ReadFile(t.fixtureFilename)
+	b, err := ioutil.ReadFile(t.fixtureFilename)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(b, v)
 }
 
 func (t *TestConversationHTTPClient) Post(uri string, dataObject interface{}) ([]byte, error) {

--- a/conversation_test.go
+++ b/conversation_test.go
@@ -164,15 +164,15 @@ type TestConversationAPI struct {
 	t        *testing.T
 }
 
-func (t TestConversationAPI) list(params conversationListParams) (ConversationList, error) {
+func (t TestConversationAPI) list(params conversationListParams) (*ConversationList, error) {
 	if t.testFunc != nil {
 		t.testFunc(t.t, params)
 	}
-	return ConversationList{Conversations: []Conversation{Conversation{ID: "123"}}, Pages: PageParams{Page: 1, PerPage: 20}}, nil
+	return &ConversationList{Conversations: []Conversation{Conversation{ID: "123"}}, Pages: PageParams{Page: 1, PerPage: 20}}, nil
 }
 
-func (t TestConversationAPI) find(id string) (Conversation, error) {
-	return Conversation{ID: "123"}, nil
+func (t TestConversationAPI) find(id string) (*Conversation, error) {
+	return &Conversation{ID: "123"}, nil
 }
 
 func (t TestConversationAPI) read(id string) (Conversation, error) {

--- a/http_client_test.go
+++ b/http_client_test.go
@@ -2,7 +2,7 @@ package intercom
 
 type TestHTTPClient struct{}
 
-func (h TestHTTPClient) Get(uri string, queryParams interface{}) ([]byte, error) { return nil, nil }
-func (h TestHTTPClient) Post(uri string, body interface{}) ([]byte, error)       { return nil, nil }
-func (h TestHTTPClient) Patch(uri string, body interface{}) ([]byte, error)      { return nil, nil }
-func (h TestHTTPClient) Delete(uri string, body interface{}) ([]byte, error)     { return nil, nil }
+func (h TestHTTPClient) Get(uri string, queryParams interface{}, v interface{}) error { return nil }
+func (h TestHTTPClient) Post(uri string, body interface{}) ([]byte, error)            { return nil, nil }
+func (h TestHTTPClient) Patch(uri string, body interface{}) ([]byte, error)           { return nil, nil }
+func (h TestHTTPClient) Delete(uri string, body interface{}) ([]byte, error)          { return nil, nil }

--- a/job.go
+++ b/job.go
@@ -75,7 +75,7 @@ func (js *JobService) AppendEvents(id string, items ...*JobItem) (JobResponse, e
 }
 
 // Find existing Job
-func (js *JobService) Find(id string) (JobResponse, error) {
+func (js *JobService) Find(id string) (*JobResponse, error) {
 	return js.Repository.find(id)
 }
 

--- a/job_api.go
+++ b/job_api.go
@@ -10,7 +10,7 @@ import (
 // JobRepository defines the interface for working with Jobs.
 type JobRepository interface {
 	save(job *JobRequest) (JobResponse, error)
-	find(id string) (JobResponse, error)
+	find(id string) (*JobResponse, error)
 }
 
 // JobAPI implements TagRepository
@@ -36,12 +36,8 @@ func (api JobAPI) save(job *JobRequest) (JobResponse, error) {
 	return savedJob, err
 }
 
-func (api JobAPI) find(id string) (JobResponse, error) {
-	fetchedJob := JobResponse{}
-	data, err := api.httpClient.Get(fmt.Sprintf("/jobs/%s", id), nil)
-	if err != nil {
-		return fetchedJob, err
-	}
-	err = json.Unmarshal(data, &fetchedJob)
-	return fetchedJob, err
+func (api JobAPI) find(id string) (*JobResponse, error) {
+	var resp *JobResponse
+	err := api.httpClient.Get(fmt.Sprintf("/jobs/%s", id), nil, &resp)
+	return resp, err
 }

--- a/job_test.go
+++ b/job_test.go
@@ -49,6 +49,6 @@ func (api *TestJobRepository) save(job *JobRequest) (JobResponse, error) {
 	return JobResponse{}, nil
 }
 
-func (api *TestJobRepository) find(id string) (JobResponse, error) {
-	return JobResponse{}, nil
+func (api *TestJobRepository) find(id string) (*JobResponse, error) {
+	return &JobResponse{}, nil
 }

--- a/segment_api.go
+++ b/segment_api.go
@@ -1,7 +1,6 @@
 package intercom
 
 import (
-	"encoding/json"
 	"fmt"
 
 	"gopkg.in/intercom/intercom-go.v2/interfaces"
@@ -9,8 +8,8 @@ import (
 
 // SegmentRepository defines the interface for working with Segments through the API.
 type SegmentRepository interface {
-	list() (SegmentList, error)
-	find(id string) (Segment, error)
+	list() (*SegmentList, error)
+	find(id string) (*Segment, error)
 }
 
 // SegmentAPI implements SegmentRepository
@@ -18,22 +17,14 @@ type SegmentAPI struct {
 	httpClient interfaces.HTTPClient
 }
 
-func (api SegmentAPI) list() (SegmentList, error) {
-	segmentList := SegmentList{}
-	data, err := api.httpClient.Get("/segments", nil)
-	if err != nil {
-		return segmentList, err
-	}
-	err = json.Unmarshal(data, &segmentList)
-	return segmentList, err
+func (api SegmentAPI) list() (*SegmentList, error) {
+	var list *SegmentList
+	err := api.httpClient.Get("/segments", nil, &list)
+	return list, err
 }
 
-func (api SegmentAPI) find(id string) (Segment, error) {
-	segment := Segment{}
-	data, err := api.httpClient.Get(fmt.Sprintf("/segments/%s", id), nil)
-	if err != nil {
-		return segment, err
-	}
-	err = json.Unmarshal(data, &segment)
+func (api SegmentAPI) find(id string) (*Segment, error) {
+	var segment *Segment
+	err := api.httpClient.Get(fmt.Sprintf("/segments/%s", id), nil, &segment)
 	return segment, err
 }

--- a/segment_api_test.go
+++ b/segment_api_test.go
@@ -1,6 +1,7 @@
 package intercom
 
 import (
+	"encoding/json"
 	"io/ioutil"
 	"testing"
 )
@@ -42,9 +43,13 @@ type TestSegmentHTTPClient struct {
 	expectedURI     string
 }
 
-func (t TestSegmentHTTPClient) Get(uri string, params interface{}) ([]byte, error) {
+func (t TestSegmentHTTPClient) Get(uri string, params interface{}, v interface{}) error {
 	if uri != t.expectedURI {
 		t.t.Errorf("Wrong endpoint called")
 	}
-	return ioutil.ReadFile(t.fixtureFilename)
+	b, err := ioutil.ReadFile(t.fixtureFilename)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(b, v)
 }

--- a/segment_test.go
+++ b/segment_test.go
@@ -21,10 +21,10 @@ type TestSegmentAPI struct {
 	t *testing.T
 }
 
-func (t TestSegmentAPI) list() (SegmentList, error) {
-	return SegmentList{Segments: []Segment{Segment{ID: "de412cad4", Name: "My Tag"}}}, nil
+func (t TestSegmentAPI) list() (*SegmentList, error) {
+	return &SegmentList{Segments: []Segment{Segment{ID: "de412cad4", Name: "My Tag"}}}, nil
 }
 
-func (t TestSegmentAPI) find(id string) (Segment, error) {
-	return Segment{ID: id}, nil
+func (t TestSegmentAPI) find(id string) (*Segment, error) {
+	return &Segment{ID: id}, nil
 }

--- a/segments.go
+++ b/segments.go
@@ -22,12 +22,12 @@ type SegmentList struct {
 }
 
 // List all Segments for the App
-func (t *SegmentService) List() (SegmentList, error) {
+func (t *SegmentService) List() (*SegmentList, error) {
 	return t.Repository.list()
 }
 
 // Find a particular Segment in the App
-func (t *SegmentService) Find(id string) (Segment, error) {
+func (t *SegmentService) Find(id string) (*Segment, error) {
 	return t.Repository.find(id)
 }
 

--- a/tag.go
+++ b/tag.go
@@ -19,7 +19,7 @@ type TagList struct {
 }
 
 // List all Tags for the App
-func (t *TagService) List() (TagList, error) {
+func (t *TagService) List() (*TagList, error) {
 	return t.Repository.list()
 }
 

--- a/tag_api.go
+++ b/tag_api.go
@@ -9,7 +9,7 @@ import (
 
 // TagRepository defines the interface for working with Tags through the API.
 type TagRepository interface {
-	list() (TagList, error)
+	list() (*TagList, error)
 	save(tag *Tag) (Tag, error)
 	delete(id string) error
 	tag(tagList *TaggingList) (Tag, error)
@@ -20,14 +20,10 @@ type TagAPI struct {
 	httpClient interfaces.HTTPClient
 }
 
-func (api TagAPI) list() (TagList, error) {
-	tagList := TagList{}
-	data, err := api.httpClient.Get("/tags", nil)
-	if err != nil {
-		return tagList, err
-	}
-	err = json.Unmarshal(data, &tagList)
-	return tagList, err
+func (api TagAPI) list() (*TagList, error) {
+	var list *TagList
+	err := api.httpClient.Get("/tags", nil, &list)
+	return list, err
 }
 
 func (api TagAPI) save(tag *Tag) (Tag, error) {

--- a/tag_api_test.go
+++ b/tag_api_test.go
@@ -1,6 +1,7 @@
 package intercom
 
 import (
+	"encoding/json"
 	"io/ioutil"
 	"testing"
 )
@@ -47,11 +48,15 @@ func TestAPITagTagging(t *testing.T) {
 	}
 }
 
-func (t TestTagHTTPClient) Get(uri string, params interface{}) ([]byte, error) {
+func (t TestTagHTTPClient) Get(uri string, params interface{}, v interface{}) error {
 	if uri != t.expectedURI {
 		t.t.Errorf("Wrong endpoint called")
 	}
-	return ioutil.ReadFile(t.fixtureFilename)
+	b, err := ioutil.ReadFile(t.fixtureFilename)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(b, v)
 }
 
 func (t TestTagHTTPClient) Post(uri string, body interface{}) ([]byte, error) {

--- a/tag_test.go
+++ b/tag_test.go
@@ -31,8 +31,8 @@ type TestTagAPI struct {
 	t *testing.T
 }
 
-func (t TestTagAPI) list() (TagList, error) {
-	return TagList{Tags: []Tag{Tag{ID: "24", Name: "My Tag"}}}, nil
+func (t TestTagAPI) list() (*TagList, error) {
+	return &TagList{Tags: []Tag{Tag{ID: "24", Name: "My Tag"}}}, nil
 }
 
 func (t TestTagAPI) save(tag *Tag) (Tag, error) {

--- a/user.go
+++ b/user.go
@@ -130,46 +130,46 @@ type scrollParams struct {
 }
 
 // FindByID looks up a User by their Intercom ID.
-func (u *UserService) FindByID(id string) (User, error) {
+func (u *UserService) FindByID(id string) (*User, error) {
 	return u.findWithIdentifiers(UserIdentifiers{ID: id})
 }
 
 // FindByUserID looks up a User by their UserID (customer supplied).
-func (u *UserService) FindByUserID(userID string) (User, error) {
+func (u *UserService) FindByUserID(userID string) (*User, error) {
 	return u.findWithIdentifiers(UserIdentifiers{UserID: userID})
 }
 
 // FindByEmail looks up a User by their Email.
-func (u *UserService) FindByEmail(email string) (User, error) {
+func (u *UserService) FindByEmail(email string) (*User, error) {
 	return u.findWithIdentifiers(UserIdentifiers{Email: email})
 }
 
-func (u *UserService) findWithIdentifiers(identifiers UserIdentifiers) (User, error) {
+func (u *UserService) findWithIdentifiers(identifiers UserIdentifiers) (*User, error) {
 	return u.Repository.find(identifiers)
 }
 
 // List all Users for App.
-func (u *UserService) List(params PageParams) (UserList, error) {
+func (u *UserService) List(params PageParams) (*UserList, error) {
 	return u.Repository.list(userListParams{PageParams: params})
 }
 
 // List all Users for App via Scroll API
-func (u *UserService) Scroll(scrollParam string) (UserList, error) {
+func (u *UserService) Scroll(scrollParam string) (*UserList, error) {
 	return u.Repository.scroll(scrollParam)
 }
 
 // List Users by Segment.
-func (u *UserService) ListBySegment(segmentID string, params PageParams) (UserList, error) {
+func (u *UserService) ListBySegment(segmentID string, params PageParams) (*UserList, error) {
 	return u.Repository.list(userListParams{PageParams: params, SegmentID: segmentID})
 }
 
 // List Users By Tag.
-func (u *UserService) ListByTag(tagID string, params PageParams) (UserList, error) {
+func (u *UserService) ListByTag(tagID string, params PageParams) (*UserList, error) {
 	return u.Repository.list(userListParams{PageParams: params, TagID: tagID})
 }
 
 // List Users Sorted.
-func (u *UserService) ListSorted(sortBy string, params PageParams) (UserList, error) {
+func (u *UserService) ListSorted(sortBy string, params PageParams) (*UserList, error) {
 	return u.Repository.list(userListParams{PageParams: params, Sort: sortBy})
 }
 

--- a/user_api_test.go
+++ b/user_api_test.go
@@ -1,6 +1,7 @@
 package intercom
 
 import (
+	"encoding/json"
 	"io/ioutil"
 	"testing"
 )
@@ -106,12 +107,16 @@ type TestUserHTTPClient struct {
 	lastQueryParams interface{}
 }
 
-func (t *TestUserHTTPClient) Get(uri string, queryParams interface{}) ([]byte, error) {
+func (t *TestUserHTTPClient) Get(uri string, queryParams interface{}, v interface{}) error {
 	if t.expectedURI != uri {
 		t.t.Errorf("URI was %s, expected %s", uri, t.expectedURI)
 	}
 	t.lastQueryParams = queryParams
-	return ioutil.ReadFile(t.fixtureFilename)
+	b, err := ioutil.ReadFile(t.fixtureFilename)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(b, v)
 }
 
 func (t *TestUserHTTPClient) Post(uri string, body interface{}) ([]byte, error) {

--- a/user_test.go
+++ b/user_test.go
@@ -64,16 +64,16 @@ type TestUserAPI struct {
 	t *testing.T
 }
 
-func (t TestUserAPI) find(params UserIdentifiers) (User, error) {
-	return User{ID: params.ID, Email: params.Email, UserID: params.UserID}, nil
+func (t TestUserAPI) find(params UserIdentifiers) (*User, error) {
+	return &User{ID: params.ID, Email: params.Email, UserID: params.UserID}, nil
 }
 
-func (t TestUserAPI) list(params userListParams) (UserList, error) {
-	return UserList{Users: []User{User{ID: "46adad3f09126dca", Email: "jamie@example.io", UserID: "aa123"}}}, nil
+func (t TestUserAPI) list(params userListParams) (*UserList, error) {
+	return &UserList{Users: []User{User{ID: "46adad3f09126dca", Email: "jamie@example.io", UserID: "aa123"}}}, nil
 }
 
-func (t TestUserAPI) scroll(scrollParam string) (UserList, error) {
-	return UserList{Users: []User{User{ID: "46adad3f09126dca", Email: "jamie@example.io", UserID: "aa123"}}}, nil
+func (t TestUserAPI) scroll(scrollParam string) (*UserList, error) {
+	return &UserList{Users: []User{User{ID: "46adad3f09126dca", Email: "jamie@example.io", UserID: "aa123"}}}, nil
 }
 
 func (t TestUserAPI) save(user *User) (User, error) {


### PR DESCRIPTION
This PR makes changes to the `Get` request logic to use pointers for the structs in order to take advantage of the fact they already get put on the HEAP during json unmarshalling and so we can avoid copying some of the larger struct with many primitive fields being copied each time.